### PR TITLE
Devcontainer improvement

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
-  "image": "mcr.microsoft.com/vscode/devcontainers/anaconda:3",
-  "customizations": {
+    "image": "mcr.microsoft.com/vscode/devcontainers/anaconda:3",
+    "features": {
+        "ghcr.io/devcontainers/features/docker-outside-of-docker": {}
+    },
+    "customizations": {
         "vscode": {
             "extensions": [
                 "ms-python.python",
@@ -11,5 +14,5 @@
         }
     },
 
-    "onCreateCommand" : "conda env create -f environment.yml"
+    "onCreateCommand" : "docker system prune -fa && conda env create -f environment.yml && echo 'source /opt/conda/bin/activate in-context-learning' > ~/.bashrc"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,5 +9,7 @@
                 "ms-azuretools.vscode-docker"
             ]
         }
-    }
+    },
+
+    "onCreateCommand" : "conda env create -f environment.yml"
 }

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ Note: If the conda environment is not automatically activated, you may need to r
 
 ### Training
 
-You can start training with:
+You can start training any pre-configured experiment by replacing `[task]` and `[architecture]` in the snippet below with your desired task and architecture. You can find an exhaustive list of pre-configured experiments at [src/conf/experiments/](https://github.com/nelson-lojo/in-context-learning/blob/main/src/conf/experiments/).
 
     ```
     cd src/
-    python train.py --config conf/experiments/any-task_relu.yml
+    python train.py --config conf/experiments/[task]_[architecture].yaml
     ```
 Note: We have implemented ReLU-attention as described in the [ViT-relu](https://arxiv.org/pdf/2309.08586.pdf) paper *and* with `L` (as described in the paper) equal to the number of tokens seen at a given sequence index (i.e. `index+1`).
 

--- a/README.md
+++ b/README.md
@@ -6,22 +6,41 @@ Paper: http://arxiv.org/abs/2208.01066 <br><br>
 
 
 ## Getting started
-You can start by cloning the repo and following the steps below.
 
-1. Install the dependencies for our code using Conda. You may need to adjust the environment YAML file depending on your setup. *(we did not)*
+<details>
+    <summary><h3>Local Environment</h3></summary>
+To get started with this codebase:
+
+1) Clone the repo  
+
+2) Install the dependencies for our code using Conda. You may need to adjust the environment YAML file depending on your setup (alternatively, you can use a Codespace (described below)).  
 
     ```
     conda env create -f environment.yml
     conda activate in-context-learning
     ```
+</details>
 
-2. Start training with:
+<details>
+<summary><h3>Codespaces (new!)</h3></summary>
+Click <a href="https://github.com/codespaces/new?hide_repo_select=true&ref=devcontainer-improvement&repo=724878312">this link</a> and step through the configurator or start a <a href="https://github.com/features/codespaces">codespace</a> directly from this repo. That's it -- dependencies will be automatically installed and you will be dropped in your default codespace editor.
+
+Note: If the conda environment is not automatically activated, you may need to run 
+
+    ```
+    source /opt/conda/bin/activate in-context-learning
+    ```
+</details>
+
+### Training
+
+You can start training with:
 
     ```
     cd src/
-    python train.py --config conf/any-task_relu_attn.yml
+    python train.py --config conf/experiments/any-task_relu.yml
     ```
-    Note: We have implemented ReLU-attention as described in the [ViT-relu](https://arxiv.org/pdf/2309.08586.pdf) paper *and* with `L` (as described in the paper) equal to the number of tokens seen at a given sequence index (i.e. `index+1`).
+Note: We have implemented ReLU-attention as described in the [ViT-relu](https://arxiv.org/pdf/2309.08586.pdf) paper *and* with `L` (as described in the paper) equal to the number of tokens seen at a given sequence index (i.e. `index+1`).
 
 ## Additional Info
 
@@ -29,6 +48,7 @@ You can start by cloning the repo and following the steps below.
     - You can find our (original) proposal at [`reports/proposal.pdf`](https://github.com/nelson-lojo/in-context-learning/blob/main/reports/proposal.pdf) 
     - Our initial submission at [`reports/draft_1.pdf`](https://github.com/nelson-lojo/in-context-learning/blob/main/reports/proposal.pdf)
     - Our final report at [`reports/final_report.pdf`](https://github.com/nelson-lojo/in-context-learning/blob/main/reports/final_report.pdf)
-- To run training on Google Colab or Kaggle, load the corresponding notebook in [`src/training_notebooks/`](https://github.com/nelson-lojo/in-context-learning/blob/main/src/training_notebooks/)
+- ~~To run training on Google Colab or Kaggle, load the corresponding notebook in [`src/training_notebooks/`](https://github.com/nelson-lojo/in-context-learning/blob/main/src/training_notebooks/)~~
     - Do note that full training took us approximately 30 hours per task for "non-causal" ReLU-attn training on a P4 GPU, so you may run into problems on preemptible platforms
+    - This is currently not supported due to large codebase changes
 - All fully trained model weights are available at [this link](https://drive.google.com/file/d/1i40FeNi5K0UzOH7I5wp32vBKCELSc8PD/view?usp=sharing)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,33 @@ You can start training any pre-configured experiment by replacing `[task]` and `
     ```
 Note: We have implemented ReLU-attention as described in the [ViT-relu](https://arxiv.org/pdf/2309.08586.pdf) paper *and* with `L` (as described in the paper) equal to the number of tokens seen at a given sequence index (i.e. `index+1`).
 
+#### New training runs
+
+You can specify a new training run by building a config file under `conf/experiments/` and using the appropriate imports. For example, to do training with the ReLU-attn transformer on the 2-layer NN task, you would produce the following:
+
+```yaml
+inherit:
+    - ../models/standard_relu.yaml
+    - ../tasks/relu_2nn_regression.yaml
+    - ../base_train.yaml
+    - ../base_curriculum.yaml
+
+training:
+    resume_id: pretrained_relu
+
+wandb:
+    name: "relu_2nn_regression_standard_relu"
+```
+
+#### New models
+
+For a new model, you would 
+1) Make the model accessible from calling `build_model(...)` in `models.py`. 
+2) Add any necessary values to `consts.py`
+3) Create a model config file in `conf/models/`
+4) Create a new training run as described above
+5) Run the training run as described above
+
 ## Additional Info
 
 - Written work:


### PR DESCRIPTION
Added conda environment creation and auto env-activation.

Notes:
* we clear the docker cache because we're just barely under the allocated disk size allowed for build processes
* nothing is done (yet) to account for devcontainers that have GPUs attached

Right now it's a bit hacky, so vscode doesn't consider the right conda environment to be `in-context-learning`. Needs testing to ensure this.